### PR TITLE
Fix install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	pip install -r requirements-dev.txt
+	pip install -r requirements.txt
 
 migrate:
 	./manage.py makemigrations

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Estamos utilizando
 
 * [Python][2] 3.5.0
 * [Django][0] 1.9.6
-* [Virtualenv Wrapper][3] 4.7.1
+* [Virtualenv][3] 15.0.1
 
 ## Wiki
 
@@ -20,32 +20,23 @@ Leia a [wiki][4].
 
 ## Como desenvolver?
 
-Baixe e rode o `setup.sh`.
-
-```bash
-# wget https://raw.githubusercontent.com/rg3915/django-experience/master/setup.sh
-# source setup.sh
-```
-
-Ou siga o passo a passo.
-
 * Clone o repositório.
-* Crie um virtualenv com Python 3.5
+* Crie um virtualenv com Python 3.5.
 * Ative o virtualenv.
 * Instale as dependências.
-* Configure a instância com o .env
-* Carregue os dados no banco
+* Configure a instância com o `.env`.
+* Execute as migrações no banco de dados.
 * Execute os testes.
 
-```bash
+```console
 git clone https://github.com/rg3915/django-experience.git
 cd django-experience
 python -m venv .venv
 source .venv/bin/activate
-PS1="(`basename \"$VIRTUAL_ENV\"`):/\W$ " # opcional
-pip install -r requirements-dev.txt
+PS1="(`basename \"$VIRTUAL_ENV\"`):/\W$ " # opcional (insere nome do virtualenv no terminal)
+python -m pip install -r requirements.txt
 cp contrib/env-sample .env
-# make initial
+python manage.py migrate
 python manage.py test
 ```
 
@@ -53,9 +44,8 @@ python manage.py test
 
 ## Changelog
 
-
 [0]: https://www.djangoproject.com/
 [1]: https://github.com/rg3915/django-experience/blob/master/ementa.md
 [2]: https://www.python.org/
-[3]: http://virtualenvwrapper.readthedocs.io/en/latest/
+[3]: https://virtualenv.readthedocs.org
 [4]: https://github.com/rg3915/django-experience/wiki


### PR DESCRIPTION
- Não tem `setup.sh` no repositótio, então limpei essa parte do
  `README.md`
- Não tem `requirements-dev.txt` no repositório, então troquei por
  `requirements.txt`
- Não tem `initial` no `Makefile`, então usei o comando padrão do Django para executar migração
- Não usamos virtualenvwrapper nas instruções, só virtualenv, então atualizei os textos e links
