### PR TITLE
Fix #28

### DIFF
--- a/djexperience/bookstore/tests/test_view_customer_add.py
+++ b/djexperience/bookstore/tests/test_view_customer_add.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from django.utils import timezone
 from django.shortcuts import resolve_url as r
 from djexperience.bookstore.forms import CustomerForm
 from djexperience.bookstore.models import Customer
@@ -47,7 +46,7 @@ class CustomerAddPostValid(TestCase):
             first_name='Adam',
             last_name='Smith',
             email='adam@example.com',
-            birthday=timezone.now()
+            birthday='2006-10-25 14:30:59'
         )
         self.resp = self.client.post(r('bookstore:customer_add'), data)
 


### PR DESCRIPTION
The issue was with the format you were passing the `birthday` value: `timezone.now()` is a Python object, nothing that users would input in a `<input type="text" …>` HTML field.

As `birthday` is a `DateTimeField`, it's rendered as a `DateTimeInput`. Django [docs says](https://docs.djangoproject.com/en/1.9/ref/forms/widgets/#datetimeinput):

> If no format argument is provided, the default format is the first format found in [DATETIME_INPUT_FORMATS](https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-DATETIME_INPUT_FORMATS) and respects [Format localization](https://docs.djangoproject.com/en/1.9/topics/i18n/formatting/).

Following the [first link](https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-DATETIME_INPUT_FORMATS) above, the default format is `2006-10-25 14:30:59`.

Therefore, just changing `data` in your test fixed it:

``` python
    def setUp(self):
        data = dict(
            first_name='Adam',
            last_name='Smith',
            email='adam@example.com',
            birthday='2006-10-25 14:30:59'
        )
        self.resp = self.client.post(r('bookstore:customer_add'), data)
```
