### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 djexperience/core/static/* linguist-vendored
+dev/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 djexperience/core/static/* linguist-vendored
 dev/* linguist-vendored
+djexperience/core/templates/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+djexperience/core/static/* linguist-vendored


### PR DESCRIPTION
O linguist do github detecta que o seu projeto tem mais códigos de CSS, Texto plano e HTML do que linhas de código de python(umas das bondades do django de escrever pouco código python ;-)) e automaticamente detecta que a linguagem do projeto é CSS. Crio o arquivo .gitattributes para ignora as rotas do static, templates, MD, para que o github começa a detectar que é um projeto na linguagem Python, mudando a categoria do seu projeto de CSS a python para que o projeto apareça na busca por linguagem em python.